### PR TITLE
Simplify bam path acquistion.

### DIFF
--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
@@ -77,7 +77,7 @@ EOS
 
 sub execute {
     my $self = shift;
-    
+
     my $input_bam = $self->get_bam();
     $self->setup_outputs();
 
@@ -379,7 +379,7 @@ sub generate_idxstats {
 
     my $cmd = join(' ',
         $self->samtools, 'idxstats',
-        "$bam", 
+        "$bam",
         '>', "$samtools_idxstats_path"
     );
 

--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
@@ -112,11 +112,9 @@ sub get_bam_from_model {
     my $bam = $build->merged_alignment_result->bam_path
       or die "Didn't find a bam file associated with build ",
              $self->model, "\n";
-    unless (-e $bam) {
-        die "Didn't find bam file: '$bam' on file system!\n";
-    }
+
     $self->status_message("Using BAM: $bam");
-    return $self->bam_file($bam);
+    return $bam;
 }
 
 sub setup_outputs {
@@ -174,19 +172,15 @@ sub get_bam {
         die "Specify only ONE '--model' or '--bam-file', NOT both!\n";
     }
 
-    my $bam;
-    if ($self->bam_file) {
-        $bam = $self->bam_file;
-    }
-    else {
-        $bam = $self->get_bam_from_model();
+    unless ($self->bam_file) {
+        $self->bam_file($self->get_bam_from_model());
     }
 
-    unless (-e $bam) {
-        die "Couldn't find bam: '$bam' on file system!\n";
+    unless (-e $self->bam_file) {
+        die "Couldn't find bam: '$self->bam_file' on file system!\n";
     }
 
-    return Path::Class::File->new($bam);
+    return Path::Class::File->new($self->bam_file);
 }
 
 sub _bin_dir {

--- a/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
+++ b/lib/perl/Genome/Model/Tools/Transcriptome/ErccMapUnaligned.pm
@@ -112,14 +112,11 @@ sub get_bam_from_model {
     my $bam = $build->merged_alignment_result->bam_path
       or die "Didn't find a bam file associated with build ",
              $self->model, "\n";
-    $bam = Path::Class::File->new($bam);
     unless (-e $bam) {
         die "Didn't find bam file: '$bam' on file system!\n";
     }
     $self->status_message("Using BAM: $bam");
-    $self->bam_file("$bam");
-
-    return $bam;
+    return $self->bam_file($bam);
 }
 
 sub setup_outputs {
@@ -179,7 +176,7 @@ sub get_bam {
 
     my $bam;
     if ($self->bam_file) {
-        $bam = Path::Class::File->new($self->bam_file);
+        $bam = $self->bam_file;
     }
     else {
         $bam = $self->get_bam_from_model();
@@ -189,7 +186,7 @@ sub get_bam {
         die "Couldn't find bam: '$bam' on file system!\n";
     }
 
-    return $bam;
+    return Path::Class::File->new($bam);
 }
 
 sub _bin_dir {


### PR DESCRIPTION
Tiny nitpick/refactor suggestion.

While reviewing the initial PR, I thought it was a little weird that `get_bam_from_model` created a File object, then stringified the newly created object to set the instance variable. This also lead to `-e` checks in both `get_bam` and `get_bam_from_model` as well as two different paths that ended up instantiating the File object. I also thought it was a little odd that a method named `get_*` had the side effect of setting an instance variable while returning a different object.

This PR (at least, I think) makes things a little simpler by reducing the possible paths through the code. There is now only a single existence check, a single `Path::Class::File->new()` call, and `get_bam_from_model` no longer has any side effects. It also removes the need for a temporary variable.

Obviously this is a pretty insignificant change overall, so feel free to take or leave it! I just started trying to type it up in a comment and realized it may be easier and quicker to just submit a PR :smiley: 
